### PR TITLE
ENH: Remove newlines from cells in to_string

### DIFF
--- a/pdftables/display.py
+++ b/pdftables/display.py
@@ -25,7 +25,7 @@ def to_string(table):
 
     result.write(hbar)
     for row_index, row in enumerate(table):
-        cells = [cell.rjust(width, ' ') for (cell, width)
+        cells = [cell.replace('\n', '').rjust(width, ' ') for (cell, width)
                  in zip(row, col_widths)]
         result.write("{:>3} | {}|\n".format(row_index, '|'.join(cells)))
     result.write(hbar)


### PR DESCRIPTION
Cleans up the to_string output incase the backend adds a bunch of new line characters.
